### PR TITLE
chore: PHP/8.4 support

### DIFF
--- a/.github/workflows/overtrue-phplint.yml
+++ b/.github/workflows/overtrue-phplint.yml
@@ -15,6 +15,6 @@ permissions:
 
 jobs:
   call-workflow:
-    uses: WorkOfStan/seablast-actions/.github/workflows/overtrue-phplint.yml@v0.2.2
+    uses: WorkOfStan/seablast-actions/.github/workflows/overtrue-phplint.yml@v0.2.3
     with:
       runs-on: "ubuntu-latest"

--- a/.github/workflows/overtrue-phplint.yml
+++ b/.github/workflows/overtrue-phplint.yml
@@ -15,6 +15,6 @@ permissions:
 
 jobs:
   call-workflow:
-    uses: WorkOfStan/seablast-actions/.github/workflows/overtrue-phplint.yml@v0.2.1
+    uses: WorkOfStan/seablast-actions/.github/workflows/overtrue-phplint.yml@v0.2.2
     with:
       runs-on: "ubuntu-latest"

--- a/.github/workflows/polish-the-code.yml
+++ b/.github/workflows/polish-the-code.yml
@@ -19,10 +19,10 @@ permissions:
 jobs:
   # Note: https://docs.github.com/en/actions/using-workflows/reusing-workflows The strategy property is not supported in any job that calls a reusable workflow.
   php-composer-unit-stan:
-    uses: WorkOfStan/seablast-actions/.github/workflows/php-composer-dependencies-reusable.yml@v0.2.1
+    uses: WorkOfStan/seablast-actions/.github/workflows/php-composer-dependencies-reusable.yml@v0.2.2
     with:
       # JSON
-      php-version: '["7.2", "7.3", "7.4", "8.2", "8.3"]'
+      php-version: '["7.2", "7.3", "7.4", "8.2", "8.3", "8.4"]'
       # OPTIONAL path with the default database configuration
       phinx-config: "./conf/phinx.dist.php"
       # OPTIONAL path where the app code is looking for the database configuration
@@ -39,7 +39,7 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Invoke the Prettier fix
-        uses: WorkOfStan/prettier-fix@v1.1.1
+        uses: WorkOfStan/prettier-fix@v1.1.3
         with:
           commit-changes: true
 
@@ -53,7 +53,7 @@ jobs:
     steps:
       - name: Invoke the PHPCS check and PHPCBF fix
         # Use the latest commit in the main branch.
-        uses: WorkOfStan/phpcs-fix@v1.0.0
+        uses: WorkOfStan/phpcs-fix@v1.0.1
         with:
           commit-changes: true
           php-version: "7.4"
@@ -61,6 +61,6 @@ jobs:
 
   super-linter:
     needs: phpcs-phpcbf
-    uses: WorkOfStan/seablast-actions/.github/workflows/linter.yml@v0.2.1
+    uses: WorkOfStan/seablast-actions/.github/workflows/linter.yml@v0.2.2
     with:
       runs-on: "ubuntu-latest"

--- a/.github/workflows/polish-the-code.yml
+++ b/.github/workflows/polish-the-code.yml
@@ -61,6 +61,6 @@ jobs:
 
   super-linter:
     needs: phpcs-phpcbf
-    uses: WorkOfStan/seablast-actions/.github/workflows/linter.yml@v0.2.2
+    uses: WorkOfStan/seablast-actions/.github/workflows/linter.yml@feature/linter-version-variants
     with:
       runs-on: "ubuntu-latest"

--- a/.github/workflows/polish-the-code.yml
+++ b/.github/workflows/polish-the-code.yml
@@ -19,7 +19,7 @@ permissions:
 jobs:
   # Note: https://docs.github.com/en/actions/using-workflows/reusing-workflows The strategy property is not supported in any job that calls a reusable workflow.
   php-composer-unit-stan:
-    uses: WorkOfStan/seablast-actions/.github/workflows/php-composer-dependencies-reusable.yml@v0.2.2
+    uses: WorkOfStan/seablast-actions/.github/workflows/php-composer-dependencies-reusable.yml@v0.2.3
     with:
       # JSON
       php-version: '["7.2", "7.3", "7.4", "8.2", "8.3", "8.4"]'
@@ -61,6 +61,6 @@ jobs:
 
   super-linter:
     needs: phpcs-phpcbf
-    uses: WorkOfStan/seablast-actions/.github/workflows/linter.yml@feature/linter-version-variants
+    uses: WorkOfStan/seablast-actions/.github/workflows/linter.yml@v0.2.3
     with:
       runs-on: "ubuntu-latest"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### `Security` in case of vulnerabilities
 
+## [0.1.4] - 2025-03-01
+
+### Fixed
+
+- PHP/8.4 support
+
 ## [0.1.3] - 2025-02-01
 
 ### Added
@@ -60,7 +66,8 @@ IdentityManager and GroupManager
 
 - PHPUnit tests for invalid emails and SQL injections attempts. Also tested automatically on GitHub.
 
-[Unreleased]: https://github.com/WorkOfStan/seablast-auth/compare/v0.1.3...HEAD
+[Unreleased]: https://github.com/WorkOfStan/seablast-auth/compare/v0.1.4...HEAD
+[0.1.4]: https://github.com/WorkOfStan/seablast-auth/compare/v0.1.3...v0.1.4
 [0.1.3]: https://github.com/WorkOfStan/seablast-auth/compare/v0.1.2...v0.1.3
 [0.1.2]: https://github.com/WorkOfStan/seablast-auth/compare/v0.1.1...v0.1.2
 [0.1.1]: https://github.com/WorkOfStan/seablast-auth/compare/v0.1...v0.1.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - PHP/8.4 support
+- For a foreign key referencing a table id, the referencing column must be of the same type—namely, an unsigned integer.
 
 ## [0.1.3] - 2025-02-01
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### `Security` in case of vulnerabilities
 
-## [0.1.4] - 2025-03-01
+## [0.1.4] - 2025-03-09
+
+### Changed
+
+- GitHub Actions version bump
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - PHP/8.4 support
-- For a foreign key referencing a table id, the referencing column must be of the same type—namely, an unsigned integer.
+- For a foreign key referencing a table ID, the referencing column must be of the same type—namely, an unsigned integer.
 
 ## [0.1.3] - 2025-02-01
 

--- a/composer.json
+++ b/composer.json
@@ -5,15 +5,15 @@
   "require": {
     "php": "^7.2 || ^8.0",
     "nette/utils": "^3.2.10 || ^4.0.5",
-    "robmorgan/phinx": "^0.10.6 || ^0.12.3",
+    "robmorgan/phinx": "^0.12.13 || ^0.13.4 || ^0.14.0 || ^0.15.5 || ^0.16.5",
     "seablast/interfaces": "^0.1",
     "symfony/mailer": "^4.4.49 || ^5 || ^6 || ^7",
     "symfony/security-csrf": "^4.4.37 || ^5 || ^6 || ^7",
-    "tracy/tracy": "^2.4.10",
-    "webmozart/assert": "^1.9.1"
+    "tracy/tracy": "^2.9.8 || ^2.10.9",
+    "webmozart/assert": "^1.10.0"
   },
   "require-dev": {
-    "phpunit/phpunit": "^4 || ^5 || ^6 || ^7 || ^8 || ^9 || ^10",
+    "phpunit/phpunit": "^8.4 || ^9 || ^10 || ^11 || ^12",
     "seablast/seablast": "^0.2.5"
   },
   "license": "MIT",

--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
   "type": "library",
   "require": {
     "php": "^7.2 || ^8.0",
-    "nette/utils": "^2.4.8 || ^3.2.2",
+    "nette/utils": "^3.2.10 || ^4.0.5",
     "robmorgan/phinx": "^0.10.6 || ^0.12.3",
     "seablast/interfaces": "^0.1",
     "symfony/mailer": "^4.4.49 || ^5 || ^6 || ^7",

--- a/conf/db/migrations/20240130222823_user.php
+++ b/conf/db/migrations/20240130222823_user.php
@@ -48,7 +48,7 @@ final class User extends AbstractMigration
             ->create();
 
         $sessionUser = $this->table('session_user');
-        $sessionUser->addColumn('user_id', 'integer')
+        $sessionUser->addColumn('user_id', 'integer', ['signed' => false])
             ->addColumn('token', 'string', ['limit' => 255])
             ->addColumn('created', 'timestamp', ['default' => 'CURRENT_TIMESTAMP'])
             ->addColumn('updated', 'timestamp', ['default' => 'CURRENT_TIMESTAMP'])

--- a/conf/db/migrations/20240130222823_user.php
+++ b/conf/db/migrations/20240130222823_user.php
@@ -35,7 +35,7 @@ final class User extends AbstractMigration
         $users->addColumn('email', 'string', ['limit' => 255])
             ->addColumn('created', 'timestamp', ['default' => 'CURRENT_TIMESTAMP'])
             ->addColumn('last_login', 'timestamp', ['null' => true, 'default' => null])
-            ->addColumn('role_id', 'integer')
+            ->addColumn('role_id', 'integer', ['signed' => false])
             ->addForeignKey('role_id', 'roles', 'id', ['delete' => 'CASCADE', 'update' => 'NO_ACTION'])
             ->addIndex(['email'], ['unique' => true]) // Add a unique index on the 'email' column
             ->create();

--- a/conf/db/migrations/20240130232507_default_user_roles.php
+++ b/conf/db/migrations/20240130232507_default_user_roles.php
@@ -38,7 +38,7 @@ final class DefaultUserRoles extends AbstractMigration
 
         // Alter 'users' table to set default roleId to 3 ('user')
         $table = $this->table('users');
-        $table->changeColumn('role_id', 'integer', ['default' => 3])
+        $table->changeColumn('role_id', 'integer', ['signed' => false, 'default' => 3])
             ->update();
     }
 
@@ -46,7 +46,7 @@ final class DefaultUserRoles extends AbstractMigration
     {
         // Remove the default value from 'role_id' column
         $table = $this->table('users');
-        $table->changeColumn('role_id', 'integer', ['default' => null])
+        $table->changeColumn('role_id', 'integer', ['signed' => false, 'default' => null])
             ->update();
 
         $this->execute('DELETE FROM roles WHERE id IN (1, 2, 3)');

--- a/conf/db/migrations/20240303082633_user_groups.php
+++ b/conf/db/migrations/20240303082633_user_groups.php
@@ -27,16 +27,16 @@ final class UserGroups extends AbstractMigration
 
         $this->table('user_group')
             ->addColumn('created', 'timestamp', ['default' => 'CURRENT_TIMESTAMP'])
-            ->addColumn('user_id', 'integer')
+            ->addColumn('user_id', 'integer', ['signed' => false])
             ->addForeignKey('user_id', 'users', 'id', ['delete' => 'CASCADE', 'update' => 'NO_ACTION'])
-            ->addColumn('group_id', 'integer')
+            ->addColumn('group_id', 'integer', ['signed' => false])
             ->addForeignKey('group_id', 'group', 'id', ['delete' => 'CASCADE', 'update' => 'NO_ACTION'])
             ->addIndex(['user_id'])
             ->create();
 
         $this->table('group_activation_tokens')
             ->addColumn('created', 'timestamp', ['default' => 'CURRENT_TIMESTAMP'])
-            ->addColumn('group_id', 'integer')
+            ->addColumn('group_id', 'integer', ['signed' => false])
             ->addForeignKey('group_id', 'group', 'id', ['delete' => 'CASCADE', 'update' => 'NO_ACTION'])
             ->addColumn('valid_from', 'datetime')
             ->addColumn('valid_to', 'datetime')

--- a/src/AuthConstant.php
+++ b/src/AuthConstant.php
@@ -15,7 +15,11 @@ class AuthConstant
      */
     public const FACEBOOK_APP_ID = 'AuthApp:FACEBOOK_APP_ID';
     /**
-     * @var string Facebook App ID
+     * @var string Flag: Social login custom button instead of native one
+     */
+    public const FLAG_SOCIAL_LOGIN_CUSTOM = 'AuthApp:FLAG_SOCIAL_LOGIN_CUSTOM';
+    /**
+     * @var string Google Client ID
      */
     public const GOOGLE_CLIENT_ID = 'AuthApp:GOOGLE_CLIENT_ID';
     /**

--- a/src/GroupManager.php
+++ b/src/GroupManager.php
@@ -105,17 +105,17 @@ class GroupManager
      * Called typically during authentication.
      *
      * @return int[]
-     * @//throws DbmsException on database statement error
+     * @throws DbmsException on database statement error
      */
     public function getGroupsByUserId(): array
     {
-        $result = $this->mysqli->queryStrict(
+        $result = $this->mysqli->query(
             'SELECT ug.group_id FROM `' . $this->tablePrefix . 'group` g INNER JOIN `' . $this->tablePrefix
             . 'user_group` ug ON g.id = ug.group_id  WHERE ug.user_id = ' . (int) $this->userId . ';'
         ); // TODO maybe just `WHERE user_id` would be sufficient. Or I want group name as well here?
-        //if (is_bool($result)) {
-        //    throw new DbmsException('Db expected.');
-        //}
+        if (is_bool($result)) {
+            throw new DbmsException('Db expected.');
+        }
         // Transform to int[]
         $groups = [];
         foreach ($result->fetch_all(MYSQLI_ASSOC) as $row) {

--- a/src/GroupManager.php
+++ b/src/GroupManager.php
@@ -51,6 +51,8 @@ class GroupManager
      * following responses:
      *  - wrong token / already activated / new activation
      *
+     * TODO: the $token comparison is case-insensitive. Make it explicit.
+     *
      * @param string $token
      * @return int self::ACTIVATION constant mimicking the HTTP response codes
      * @throws DbmsException on database statement error

--- a/src/GroupManager.php
+++ b/src/GroupManager.php
@@ -105,21 +105,21 @@ class GroupManager
      * Called typically during authentication.
      *
      * @return int[]
-     * @throws DbmsException on database statement error
+     * @//throws DbmsException on database statement error
      */
     public function getGroupsByUserId(): array
     {
-        $result = $this->mysqli->query(
+        $result = $this->mysqli->queryStrict(
             'SELECT ug.group_id FROM `' . $this->tablePrefix . 'group` g INNER JOIN `' . $this->tablePrefix
             . 'user_group` ug ON g.id = ug.group_id  WHERE ug.user_id = ' . (int) $this->userId . ';'
         ); // TODO maybe just `WHERE user_id` would be sufficient. Or I want group name as well here?
-        if (is_bool($result)) {
-            throw new DbmsException('Db expected.');
-        }
+        //if (is_bool($result)) {
+        //    throw new DbmsException('Db expected.');
+        //}
         // Transform to int[]
         $groups = [];
         foreach ($result->fetch_all(MYSQLI_ASSOC) as $row) {
-            Assert::isArray($row);
+            //Assert::isArray($row);
             Assert::scalar($row['group_id']);
             $groups[] = (int) $row['group_id'];
         }

--- a/src/GroupManager.php
+++ b/src/GroupManager.php
@@ -119,7 +119,6 @@ class GroupManager
         // Transform to int[]
         $groups = [];
         foreach ($result->fetch_all(MYSQLI_ASSOC) as $row) {
-            //Assert::isArray($row);
             Assert::scalar($row['group_id']);
             $groups[] = (int) $row['group_id'];
         }


### PR DESCRIPTION
### Changed

- GitHub Actions version bump

### Fixed

- PHP/8.4 support
- For a foreign key referencing a table ID, the referencing column must be of the same type—namely, an unsigned integer.