### PR TITLE
feat: use cryptographically secure random bytes for session tokens

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,3 +10,5 @@ updates:
     schedule:
       # Check for updates to GitHub Actions every month
       interval: "monthly"
+    cooldown:
+      default-days: 7

--- a/.github/workflows/polish-the-code.yml
+++ b/.github/workflows/polish-the-code.yml
@@ -28,7 +28,8 @@ jobs:
     permissions:
       contents: read
       pull-requests: write
-      issues: write # so that it can actually write pr-comments
+      # so that it can actually write pr-comments
+      issues: write
     # Limit the running time
     timeout-minutes: 10
     steps:

--- a/.github/workflows/polish-the-code.yml
+++ b/.github/workflows/polish-the-code.yml
@@ -33,18 +33,21 @@ jobs:
     # Limit the running time
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
-          ref: ${{ github.event.pull_request.head.sha }} # checkout PR HEAD commit
-          fetch-depth: 0 # required for merge-base check
+          # checkout PR HEAD commit
+          ref: ${{ github.event.pull_request.head.sha }}
+          # required for merge-base check
+          fetch-depth: 0
           persist-credentials: false
       - uses: commit-check/commit-check-action@v2
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # use GITHUB_TOKEN because use of pr-comments
+          # use GITHUB_TOKEN because use of pr-comments
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           message: true
           # to accept dependabot/github_actions/*
-          # branch: false
+          branch: false
           author-name: true
           author-email: true
           job-summary: true
@@ -52,7 +55,7 @@ jobs:
 
   # Note: https://docs.github.com/en/actions/using-workflows/reusing-workflows The strategy property is not supported in any job that calls a reusable workflow.
   php-composer-unit-stan:
-    uses: WorkOfStan/seablast-actions/.github/workflows/php-composer-dependencies-reusable.yml@v0.2.7
+    uses: WorkOfStan/seablast-actions/.github/workflows/php-composer-dependencies-reusable.yml@v0.2.11
     with:
       # JSON
       php-version: '["7.2", "7.3", "7.4", "8.0", "8.1", "8.2", "8.3", "8.4", "8.5"]'
@@ -93,6 +96,6 @@ jobs:
 
   super-linter:
     needs: phpcs-phpcbf
-    uses: WorkOfStan/seablast-actions/.github/workflows/linter.yml@v0.2.7
+    uses: WorkOfStan/seablast-actions/.github/workflows/linter.yml@v0.2.11
     with:
       runs-on: "ubuntu-latest"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,7 +14,7 @@ Key runtime classes:
 
 ## Change Rules
 
-- Never remove comments unless the comment is a TODO that the change fully solves; stale comments should be rewritten in accurate English.
+- Never remove comments unless the comment is a todo that the change fully solves; stale comments should be rewritten in accurate English.
 - Keep `CHANGELOG.md` updated in English for user-visible or security-relevant changes.
 - Update this `AGENTS.md` when agent-facing setup, commands, or project conventions change.
 - Treat this as auth/security-sensitive code: do not log raw login tokens, OAuth tokens, email tokens, session tokens, or Remember Me tokens.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,73 @@
+# Agent Notes
+
+## Project
+
+Seablast Auth is a PHP library for passwordless email-token login, user sessions, Remember Me cookies, RBAC roles, user groups, and optional Google/Facebook social login in Seablast applications.
+
+Key runtime classes:
+
+- `Seablast\Auth\IdentityManager`: email token login, session tokens, Remember Me cookies, authenticated user identity.
+- `Seablast\Auth\GroupManager`: group membership and group activation token handling.
+- `Seablast\Auth\UserModel`: bundled `/user` login/logout model.
+- `Seablast\Auth\Models\ApiSocialLoginModel`: bundled `/api/social-login` model.
+- `Seablast\Auth\MailOut`: Symfony Mailer wrapper using `SeablastConfiguration`.
+
+## Change Rules
+
+- Never remove comments unless the comment is a TODO that the change fully solves; stale comments should be rewritten in accurate English.
+- Keep `CHANGELOG.md` updated in English for user-visible or security-relevant changes.
+- Update this `AGENTS.md` when agent-facing setup, commands, or project conventions change.
+- Treat this as auth/security-sensitive code: do not log raw login tokens, OAuth tokens, email tokens, session tokens, or Remember Me tokens.
+- Prefer small, compatible changes; the package supports PHP `>=7.2 <8.6`.
+
+## Commands
+
+On Windows, do not run `.sh` helper scripts directly from PowerShell. Use Git Bash explicitly when a shell helper is needed.
+
+PHPUnit:
+
+```powershell
+.\vendor\bin\phpunit
+```
+
+PHP syntax checks:
+
+```powershell
+php -l src\IdentityManager.php
+```
+
+PHPStan setup/check:
+
+```powershell
+& "C:\Program Files\Git\bin\bash.exe" -lc "./blast.sh phpstan"
+```
+
+PHPStan cleanup:
+
+```powershell
+& "C:\Program Files\Git\bin\bash.exe" -lc "./blast.sh phpstan-remove"
+```
+
+Composer install:
+
+```powershell
+$env:COMPOSER_CACHE_DIR = "$PWD\.composer-cache"
+php "C:\ProgramData\ComposerSetup\bin\composer.phar" install
+```
+
+Do not modify Composer itself and do not run `composer self-update`.
+
+## Local Setup
+
+- DB-backed tests expect a working local MySQL test database configured through `conf/phinx.local.php`.
+- `conf/phinx.local.php` is local/private and should not be committed.
+- Migrations for consumers live in `conf/db/migrations`.
+- Do not inspect, lint, or recurse into `.tmp`, `vendor`, or build artifacts unless a task specifically requires it.
+
+## Security Expectations
+
+- Escape or parameterize user-controlled values before SQL use; prefer prepared statements for larger refactors.
+- Use `random_bytes()`-based tokens for login/session/Remember Me tokens.
+- Remember Me cookies must be HTTPS-only and HttpOnly.
+- `AuthConstant::FLAG_REMEMBER_ME_COOKIE` controls Remember Me creation and reading in bundled models.
+- Social-login validation must check provider audience/client ID, issuer, email, and expiration where available.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### `Security` in case of vulnerabilities
 
-## [0.1.9] - 2026-06-21
+## [0.1.9] - Unreleased
+
+feat: use cryptographically secure random bytes for session tokens
 
 ### Added
 
@@ -29,7 +31,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Updated README and Composer description wording for current APIs and PHP support.
+- Updated readme and Composer description wording for current APIs and PHP support.
 - Updated `blast.sh` from Seablast v0.2.11 to v0.2.17.3 helper wording and conditional PHPStan PHPUnit plugin installation.
 - Adjusted GitHub workflow permissions comments for pull-request comments.
 - Replaced session `uniqid()` values with random tokens from the existing token generator.
@@ -42,10 +44,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `AuthConstant::FLAG_REMEMBER_ME_COOKIE` now controls Remember Me cookie creation as well as reading in bundled models.
 - Google tokeninfo validation now handles missing or malformed `aud`, `iss`, `email`, and `exp` fields safely.
 - Group activation token lookup is explicitly case-insensitive and limited to one matching token.
-- README `MailOut` usage now matches the `MailOut(SeablastConfiguration $configuration)` constructor.
+- Readme `MailOut` usage now matches the `MailOut(SeablastConfiguration $configuration)` constructor.
 
 ### Security
 
+- Make logout to use deleteSessionToken method
 - Social-login failure logging no longer records raw OAuth or ID tokens.
 - Session tokens now use cryptographically secure random bytes instead of `uniqid()`.
 - Google social-login validation checks audience, issuer, email format, and expiration when present.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,37 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### `Security` in case of vulnerabilities
 
+## [0.1.9] - 2026-06-21
+
+### Added
+
+- `AGENTS.md` with project, command, testing, and security guidance for coding agents.
+- `IdentityManager::setRememberMeCookieEnabled()` to let bundled models and direct users disable Remember Me cookie creation and reads.
+- PHPUnit coverage for Google social-login tokeninfo validation without network or database access.
+
+### Changed
+
+- Updated README and Composer description wording for current APIs and PHP support.
+- Updated `blast.sh` from Seablast v0.2.11 to v0.2.17.3 helper wording and conditional PHPStan PHPUnit plugin installation.
+- Adjusted GitHub workflow permissions comments for pull-request comments.
+- Replaced session `uniqid()` values with random tokens from the existing token generator.
+- `SocialLoginGoogle` accepts an optional Guzzle client for isolated testing.
+
+### Fixed
+
+- Escaped email and token values in IdentityManager login, token validation, session deletion, and user lookup paths.
+- Write queries in IdentityManager now throw `DbmsException` on database errors.
+- `AuthConstant::FLAG_REMEMBER_ME_COOKIE` now controls Remember Me cookie creation as well as reading in bundled models.
+- Google tokeninfo validation now handles missing or malformed `aud`, `iss`, `email`, and `exp` fields safely.
+- Group activation token lookup is explicitly case-insensitive and limited to one matching token.
+- README `MailOut` usage now matches the `MailOut(SeablastConfiguration $configuration)` constructor.
+
+### Security
+
+- Social-login failure logging no longer records raw OAuth or ID tokens.
+- Session tokens now use cryptographically secure random bytes instead of `uniqid()`.
+- Google social-login validation checks audience, issuer, email format, and expiration when present.
+
 ## [0.1.8] - 2025-12-27
 
 feat: add PHP/8.5 support
@@ -132,7 +163,8 @@ IdentityManager and GroupManager
 
 - PHPUnit tests for invalid emails and SQL injections attempts. Also tested automatically on GitHub.
 
-[Unreleased]: https://github.com/WorkOfStan/seablast-auth/compare/v0.1.8...HEAD
+[Unreleased]: https://github.com/WorkOfStan/seablast-auth/compare/v0.1.9...HEAD
+[0.1.9]: https://github.com/WorkOfStan/seablast-auth/compare/v0.1.8...v0.1.9
 [0.1.8]: https://github.com/WorkOfStan/seablast-auth/compare/v0.1.7...v0.1.8
 [0.1.7]: https://github.com/WorkOfStan/seablast-auth/compare/v0.1.6...v0.1.7
 [0.1.6]: https://github.com/WorkOfStan/seablast-auth/compare/v0.1.5...v0.1.6

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### `Security` in case of vulnerabilities
 
-## [0.1.9] - Unreleased
+## [0.1.9] - 2026-07-07
 
 feat: use cryptographically secure random bytes for session tokens
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,13 +40,14 @@ feat: use cryptographically secure random bytes for session tokens
 
 ### Fixed
 
-- Escaped email and token values in IdentityManager login, token validation, session deletion, and user lookup paths.
+- Escape email and token values in IdentityManager login, token validation, session deletion, and user lookup paths.
 - Write queries in IdentityManager now throw `DbmsException` on database errors.
 - `AuthConstant::FLAG_REMEMBER_ME_COOKIE` now controls Remember Me cookie creation as well as reading in bundled models.
 - Google tokeninfo validation now handles missing or malformed `aud`, `iss`, `email`, and `exp` fields safely.
 - Group activation token lookup is explicitly case-insensitive and limited to one matching token.
 - Readme `MailOut` usage now matches the `MailOut(SeablastConfiguration $configuration)` constructor.
-- Removes never-logged-in users older than 15 minutes before creating or reusing login users.
+- Remove never-logged-in users older than 15 minutes before creating or reusing login users.
+- Set the query-log user immediately after resolving `user_id`, before refreshing `session_user.updated`
 
 ### Security
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ feat: use cryptographically secure random bytes for session tokens
 - Adjusted GitHub workflow permissions comments for pull-request comments.
 - Replaced session `uniqid()` values with random tokens from the existing token generator.
 - `SocialLoginGoogle` accepts an optional Guzzle client for isolated testing.
+- Update session access timestamp writes to run only after five minutes of inactivity.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@ feat: use cryptographically secure random bytes for session tokens
 - Google tokeninfo validation now handles missing or malformed `aud`, `iss`, `email`, and `exp` fields safely.
 - Group activation token lookup is explicitly case-insensitive and limited to one matching token.
 - Readme `MailOut` usage now matches the `MailOut(SeablastConfiguration $configuration)` constructor.
+- Removes never-logged-in users older than 15 minutes before creating or reusing login users.
 
 ### Security
 

--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ Note 2: vendor/seablast is accessible for Seablast apps, so the web browser asse
 
 ### Social login
 
-Existence of configuration strings 'FACEBOOK_APP_ID' or 'GOOGLE_CLIENT_ID' imply option to login by these platforms respectively.
+Existence of configuration strings `FACEBOOK_APP_ID` or `GOOGLE_CLIENT_ID` imply option to login by these platforms respectively.
 
 Note 1: social login can be deactivated in an app by `->deactivate(AuthConstant::FLAG_USE_SOCIAL_LOGIN)` in the configuration.
 
@@ -148,7 +148,7 @@ Run [./test.sh](./test.sh) for essential PHPUnit tests:
 
 - create token and use it,
 - check its disapperance as it's valid only once,
-- invalid emails is not accepted,
+- an invalid email format is not accepted,
 - SQL injection attempts is not accepted.
 
 ## TODO

--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
-# `Seablast\Auth`
+# Seablast Auth
 
 A no-password authentication and authorization extension for [Seablast for PHP](https://github.com/WorkOfStan/seablast) apps.
 This extension facilitates secure user verification and efficient access control.
 
-Optionally, `Seablast\Auth` has a ligthweight integration with Google and Facebook to support social authentication, allowing seamless sign-in through various social media platforms.
+Optionally, Seablast Auth has a ligthweight integration with Google and Facebook to support social authentication, allowing seamless sign-in through various social media platforms.
 Integrable via Composer, it activates only when required, equipping your app with essential security features effortlessly.
-If your Seablast-based application necessitates user authentication or resource authorization, incorporating `Seablast\Auth` will equip it with these capabilities instantly.
-(For applications that do not require these features, `Seablast\Auth` can simple be not included to maintain a lighter application footprint.)
+If your Seablast-based application necessitates user authentication or resource authorization, incorporating Seablast Auth will equip it with these capabilities instantly.
+(For applications that do not require these features, Seablast Auth can simple be not included to maintain a lighter application footprint.)
 
 ## User management
 
@@ -89,7 +89,7 @@ The successful login behaviour is reload the current page or go to a social logi
         ->setString(AuthConstant::SOCIAL_LOGIN_SUCCESS_URL, '') // empty OR not set => just reload; otherwise go to the fully qualified URL of a social login success page
 ```
 
-Note 1: already Seablast::v0.2.5 is using the default settings in the [conf/app.conf.php](conf/app.conf.php), so Seablast/Auth configuration is used with v0.2.5 forward.
+Note 1: already Seablast::v0.2.5 is using the default settings in the [conf/app.conf.php](conf/app.conf.php), so Seablast Auth configuration is used with v0.2.5 forward.
 
 `send-auth-token.js` (since Seablast::v0.2.10) expects the route `/api/social-login` as configured in [app.conf.php](conf/app.conf.php) and provider either `facebook` or `google`.
 
@@ -121,7 +121,7 @@ Note 3: The new Google Identity Services no longer opens a traditional pop‑up 
 
 ### MailOut::send() method is a generic mail sender built on top of Symfony Mailer
 
-Sending of emails to users MUST be activated, so that `$this->configuration->flag->status(SeablastConstant::USER_MAIL_ENABLED)` is true.
+In order to send emails, the `SeablastConstant::USER_MAIL_ENABLED` flag MUST be activated.
 
 ```php
   // Usage:

--- a/README.md
+++ b/README.md
@@ -3,10 +3,10 @@
 A no-password authentication and authorization extension for [Seablast for PHP](https://github.com/WorkOfStan/seablast) apps.
 This extension facilitates secure user verification and efficient access control.
 
-Optionally, Seablast Auth has a ligthweight integration with Google and Facebook to support social authentication, allowing seamless sign-in through various social media platforms.
+Optionally, Seablast Auth has a lightweight integration with Google and Facebook to support social authentication, allowing seamless sign-in through various social media platforms.
 Integrable via Composer, it activates only when required, equipping your app with essential security features effortlessly.
 If your Seablast-based application necessitates user authentication or resource authorization, incorporating Seablast Auth will equip it with these capabilities instantly.
-(For applications that do not require these features, Seablast Auth can simple be not included to maintain a lighter application footprint.)
+(For applications that do not require these features, Seablast Auth can simply be omitted to maintain a lighter application footprint.)
 
 ## User management
 
@@ -23,7 +23,7 @@ When just getting the identity of a logged-in user is needed:
     $identity = new IdentityManager($this->configuration->mysqli());
     // If prefix is used, inject it
     $identity->setTablePrefix($this->configuration->dbmsTablePrefix());
-    // To make Remember me Cookies predictable = avoid conflicts, inject a cookie path
+    // To make Remember Me cookies predictable and thus avoid conflicts, inject a cookie path
     $identity->setCookiePath($this->configuration->getString(SeablastConstant::SB_SESSION_SET_COOKIE_PARAMS_PATH));
 ```
 
@@ -63,8 +63,8 @@ session_set_cookie_params(
 ): bool
 ```
 
-Note: sbRememberMe cookie created/read only if the web is accessed over HTTPS and if allowed by `AuthApp:FLAG_REMEMBER_ME_COOKIE` (allowed by default).
-(todo check whether if not allowed, it is really not created or just not read)
+Note: `sbRememberMe` cookie is created/read only if the web is accessed over HTTPS and if allowed by `AuthApp:FLAG_REMEMBER_ME_COOKIE` (allowed by default).
+Bundled models inject the flag into `IdentityManager`; direct `IdentityManager` users can call `setRememberMeCookieEnabled(false)`.
 
 ### Routing
 
@@ -83,13 +83,13 @@ but if you want to customize it, configure path to your own template within your
         )
 ```
 
-The successful login behaviour is reload the current page or go to a social login success page:
+Successful login either reloads the current page or goes to a social login success page:
 
 ```php
         ->setString(AuthConstant::SOCIAL_LOGIN_SUCCESS_URL, '') // empty OR not set => just reload; otherwise go to the fully qualified URL of a social login success page
 ```
 
-Note 1: already Seablast::v0.2.5 is using the default settings in the [conf/app.conf.php](conf/app.conf.php), so Seablast Auth configuration is used with v0.2.5 forward.
+Note 1: Seablast::v0.2.5 and newer use the default settings in the [conf/app.conf.php](conf/app.conf.php), so Seablast Auth configuration is loaded automatically.
 
 `send-auth-token.js` (since Seablast::v0.2.10) expects the route `/api/social-login` as configured in [app.conf.php](conf/app.conf.php) and provider either `facebook` or `google`.
 
@@ -111,13 +111,13 @@ Note 2: vendor/seablast is accessible for Seablast apps, so the web browser asse
 
 ### Social login
 
-Existence of configuration strings `FACEBOOK_APP_ID` or `GOOGLE_CLIENT_ID` imply option to login by these platforms respectively.
+The presence of configuration strings `FACEBOOK_APP_ID` or `GOOGLE_CLIENT_ID` enables login by these platforms respectively.
 
 Note 1: social login can be deactivated in an app by `->deactivate(AuthConstant::FLAG_USE_SOCIAL_LOGIN)` in the configuration.
 
 Note 2: send-auth-token.js is expected in seablast directory, which needs at least Seablast v0.2.10. (These arguments `window.sendAuthToken(token, apiRoute, errorLogger);` are processed since Seablast::v0.2.13.)
 
-Note 3: The new Google Identity Services no longer opens a traditional pop‑up account chooser; instead, it displays the One Tap UI.
+Note 3: The new Google Identity Services no longer opens a traditional pop-up account chooser; instead, it displays the One Tap UI.
 
 ### MailOut::send() method is a generic mail sender built on top of Symfony Mailer
 
@@ -126,12 +126,14 @@ In order to send emails, the `SeablastConstant::USER_MAIL_ENABLED` flag MUST be 
 ```php
   // Usage:
   use Seablast\Auth\MailOut;
-  $sendMail = new MailOut('smtp://smtp.example.com:587', 'noreply@example.com');
+
+  /** @var \Seablast\Seablast\SeablastConfiguration $seablastConfiguration */
+  $sendMail = new MailOut($seablastConfiguration);
   $sendMail->send(
-    to: 'user@example.com',
-    subject: 'Login link',
-    textBody: "Open this URL: https://app.example.com/?token=XYZ",
-    options: [
+    'user@example.com', // to
+    'Login link', // subject
+    "Open this URL: https://app.example.com/?token=XYZ", // textBody
+    [
       'cc'   => ['cc1@example.com', 'cc2@example.com'], // optional
       'bcc'  => 'audit@example.com',                    // optional, can be string or array
       'html' => '<p>Open this URL: <a href="https://app.example.com/?token=XYZ">Login</a></p>', // optional
@@ -144,10 +146,10 @@ In order to send emails, the `SeablastConstant::USER_MAIL_ENABLED` flag MUST be 
 
 ## Testing
 
-Run [./test.sh](./test.sh) for essential PHPUnit tests:
+Run `.\vendor\bin\phpunit` on Windows for essential PHPUnit tests. From Git Bash, [./test.sh](./test.sh) also prepares the testing database migration before running PHPUnit.
 
 - create token and use it,
-- check its disapperance as it's valid only once,
+- check its disappearance as it's valid only once,
 - an invalid email format is not accepted,
 - SQL injection attempts is not accepted.
 

--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ Integrable via Composer, it activates only when required, equipping your app wit
 If your Seablast-based application necessitates user authentication or resource authorization, incorporating Seablast Auth will equip it with these capabilities instantly.
 (For applications that do not require these features, Seablast Auth can simply be omitted to maintain a lighter application footprint.)
 
+Note: Ensure that your PHP and MySQL timezones are properly set, as the code uses CURRENT_TIMESTAMP for time-related operations. (It would be possible to use purely SQL statements with `INTERVAL` but at a cost of not caching the SQL responses.)
+
 ## User management
 
 - RBAC (Role-Based Access Control) supported

--- a/blast.sh
+++ b/blast.sh
@@ -1,9 +1,16 @@
 #!/bin/bash
 # blast.sh - Management script for deployment and development of a Seablast application
-# Seablast:v0.2.14
+# Seablast:v0.2.17.3
+# Fail fast on real script errors:
+# -e: stop on unexpected non-zero exit codes
+# -u: treat unset variables as errors, which makes argument handling stricter
+# -o pipefail: fail a pipeline when any command in it fails
+set -euo pipefail
+
 # Usage:
 #   ./blast.sh                          # Runs assemble + creates required folders + checks web inaccessibility
-#   ./blast.sh --base-url http://localhost  # Checks if defined folders are inaccessible at http://localhost
+#   ./blast.sh --base-url http://localhost  # Runs the default action with a custom base URL for folder checks
+#   ./blast.sh clean                    # Previews and deletes temporary cache/audio marker files after confirmation
 #   ./blast.sh main                     # Switches to the main branch (after confirmation)
 #   ./blast.sh phpstan                  # Runs PHPStan without --pro
 #   ./blast.sh phpstan-pro              # Runs PHPStan with --pro
@@ -19,6 +26,12 @@ WARNING='\033[0;31m'   # Red for warnings
 display_header() { printf "${HIGHLIGHT}%s${NC}\n" "$1"; }
 display_warning() { printf "${WARNING}%s${NC}\n" "$1"; }
 
+# Shared usage output so CLI validation errors stay consistent.
+print_usage() {
+	echo "Usage: ./blast.sh [--base-url http://example.com] [clean|main|phpstan|phpstan-pro|phpstan-remove|self-update]"
+	echo "(See the beginning of the code for the explanation.)"
+}
+
 # Default base URL (can be overridden by --base-url)
 BASE_URL="http://localhost"
 
@@ -30,12 +43,17 @@ check_web_inaccessibility() {
 	local path="$1"
 	local url="${BASE_URL}${path}"
 	local status_code
-	status_code=$(curl -o /dev/null -s -w "%{http_code}" "$url")
 
-	if [ "$status_code" -eq 404 ] || [ "$status_code" -eq 403 ]; then
-		echo "✅ $url is correctly blocked ($status_code)."
+	# With `set -e`, run curl inside `if` so connection problems only warn and do not
+	# abort the whole setup when a local web server is temporarily unavailable.
+	if status_code=$(curl -o /dev/null -s -w "%{http_code}" "$url" 2>/dev/null); then
+		if [ "$status_code" -eq 404 ] || [ "$status_code" -eq 403 ]; then
+			echo "[OK] $url is correctly blocked ($status_code)."
+		else
+			display_warning "Warning: $url is accessible with status $status_code."
+		fi
 	else
-		display_warning "⚠️  Warning: $url is accessible with status $status_code."
+		display_warning "Warning: $url could not be checked because curl could not reach it."
 	fi
 }
 
@@ -48,14 +66,15 @@ setup_environment() {
 	if command -v curl &>/dev/null; then
 		has_curl=true
 	else
-		display_warning "⚠️  Warning: curl is not installed, so security of folders cannot be tested."
+		display_warning "Warning: curl is not installed, so security of folders cannot be tested."
 	fi
 	for folder in "${paths[@]}"; do
 		[ ! -d "$folder" ] && mkdir -p "$folder" && display_header "Created missing folder: $folder"
 		$has_curl && check_web_inaccessibility "/$folder/"
 	done
 
-	# Create local config if not present but the dist template is available, if newly created, then stop the script so that the admin may adapt the newly created config
+	# Create local config if not present but the dist template is available. If newly
+	# created, then stop the script so that the admin may adapt the new config first.
 	[[ ! -f "conf/app.conf.local.php" && -f "conf/app.conf.dist.php" ]] && cp -p conf/app.conf.dist.php conf/app.conf.local.php && display_warning "Check/modify the newly created conf/app.conf.local.php" && exit 0
 
 	# conf/phinx.local.php or at least conf/phinx.dist.php is required
@@ -84,11 +103,38 @@ assemble() {
 	display_header "-- Running database migrations --"
 	vendor/bin/phinx migrate -e development --configuration ./conf/phinx.local.php
 	display_header "-- Running database TESTING migrations --"
-	# In order to properly unit test all features, set-up a test database, put its credentials to testing section of the phinx configuration file and run phinx migrate -e testing before phpunit
-	# Drop tables in the testing database if changes were made to migrations
+	# In order to properly unit test all features, set-up a test database, put its
+	# credentials to the testing section of the phinx configuration file and run
+	# phinx migrate -e testing before phpunit.
+	# Drop tables in the testing database if changes were made to migrations.
 	vendor/bin/phinx migrate -e testing --configuration ./conf/phinx.local.php
 
 	run_phpunit
+}
+
+# Previews and removes temporary files created during development
+clean_temp_files() {
+	display_header "-- Files to be deleted (preview) --"
+	# ls returns non-zero when no glob matches, which is acceptable for this preview.
+	# We do not want the script to stop in that case, so we append "|| true".
+	ls -1 cache/*.php cache/*.lock uploads/audios/*.del 2>/dev/null || true
+	echo
+
+	read -r -p "Do you really want to delete the files listed above? Type YES to continue: " confirm
+	if [[ "${confirm}" != "YES" ]]; then
+		echo "Aborted."
+		exit 0
+	fi
+
+	display_header "-- Deleting temporary files --"
+	# -v: verbose, prints the name of each removed file
+	# -f: force, ignore nonexistent files and do not prompt
+	# Keep "2>/dev/null || true" so unmatched globs do not abort the script under
+	# `set -e` in environments with slightly different shell behaviour.
+	rm -fv cache/*.php cache/*.lock 2>/dev/null || true
+	rm -fv uploads/audios/*.del 2>/dev/null || true
+
+	echo "Done."
 }
 
 # Switches to the main branch
@@ -125,7 +171,7 @@ run_phpstan() {
 # Removes PHPStan package
 phpstan_remove() {
 	display_header "-- Removing PHPStan package --"
-	# It doesn't matter if phpstan/phpstan-phpunit was not required before
+	# It does not matter if phpstan/phpstan-phpunit was not required before.
 	composer remove --dev phpstan/phpstan-phpunit
 	composer remove --dev phpstan/phpstan-webmozart-assert
 }
@@ -145,14 +191,18 @@ self_update() {
 	fi
 }
 
-# Parse optional base-url argument
-case "$1" in
---base-url)
-	shift
-	BASE_URL="$1"
-	shift
-	;;
-esac
+# Parse optional base-url argument.
+# Under `set -u`, use `${1-}` / `${2-}` so a missing CLI value can be handled
+# with a friendly error instead of an immediate "unbound variable" exit.
+if [[ "${1-}" == "--base-url" ]]; then
+	if [[ -z "${2-}" ]]; then
+		display_warning "Missing value for --base-url."
+		print_usage
+		exit 1
+	fi
+	BASE_URL="$2"
+	shift 2
+fi
 
 # Default behavior when no arguments are provided
 if [ $# -eq 0 ]; then
@@ -164,7 +214,10 @@ if [ $# -eq 0 ]; then
 fi
 
 # Handle command-line parameters
-case "$1" in
+case "${1-}" in
+clean)
+	clean_temp_files
+	;;
 main)
 	printf "Switches your working tree to the specified branch: main. Git will then fetch from origin (showing you a verbose progress report), bringing in all branches and tags, deleting any remote-tracking branches that have been removed on the server, and then merge (not rebase) the corresponding remote branch into your current branch.\n"
 	read -r -n1 -p "Continue? [y/N] " reply
@@ -188,9 +241,8 @@ self-update)
 	self_update
 	;;
 *)
-	display_warning "❌ Unknown option: $1"
-	echo "Usage: ./blast.sh [--base-url http://example.com][main|phpstan|phpstan-pro|phpstan-remove|self-update]"
-	echo "(See the beginning of the code for the explanation.)"
+	display_warning "Unknown option: ${1-}"
+	print_usage
 	exit 1
 	;;
 esac

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
   "name": "seablast/auth",
-  "description": "No-password authentication and authorisation library for Seablast for PHP",
+  "description": "No-password authentication and authorization library for Seablast for PHP",
   "type": "library",
   "require": {
     "php": ">=7.2 <8.6",

--- a/src/AuthConstant.php
+++ b/src/AuthConstant.php
@@ -31,7 +31,7 @@ class AuthConstant
      */
     public const FLAG_USE_SOCIAL_LOGIN = 'AuthApp:FLAG_USE_SOCIAL_LOGIN';
     /**
-     * @var string string email address from which emails are sent
+     * @var string string: Display name for the default sender email address
      */
     public const FROM_MAIL_NAME = 'AuthApp:SB:FROM_MAIL:NAME';
     /**
@@ -43,19 +43,19 @@ class AuthConstant
      */
     public const SOCIAL_LOGIN_SUCCESS_URL = 'AuthApp:SOCIAL_LOGIN_SUCCESS_URL';
     /**
-     * @var string Subject of login email
+     * @var string string: Subject of login email
      */
     public const SUBJECT_EMAIL_LOGIN = 'AuthApp:SUBJECT_EMAIL_LOGIN';
     /**
-     * @var string Subject of registration email
+     * @var string string: Subject of registration email
      */
     public const SUBJECT_EMAIL_REGISTRATION = 'AuthApp:SUBJECT_EMAIL_REGISTRATION';
     /**
-     * @var string Text of login email (%URL% will be replace by the login URL)
+     * @var string string: Text of login email (%URL% will be replaced by the login URL)
      */
     public const TEXT_EMAIL_LOGIN = 'AuthApp:TEXT_EMAIL_LOGIN';
     /**
-     * @var string Text of registration email (%URL% will be replace by the activation URL)
+     * @var string string: Text of registration email (%URL% will be replaced by the activation URL)
      */
     public const TEXT_EMAIL_REGISTRATION = 'AuthApp:TEXT_EMAIL_REGISTRATION';
     /**

--- a/src/GroupManager.php
+++ b/src/GroupManager.php
@@ -60,14 +60,17 @@ class GroupManager
     public function activateGroupByToken(string $token): int
     {
         // Check token validity
+        // Compare token case-insensitively to avoid issues with letter case.
+        // Using LOWER() on both sides is portable across MySQL/MariaDB.
+        $escapedToken = $this->mysqli->real_escape_string($token);
         $resultToken = $this->mysqli->query('SELECT * FROM `' . $this->tablePrefix
-            . 'group_activation_tokens` WHERE token = "' . $this->mysqli->real_escape_string($token)
-            . '" AND valid_from <= NOW() AND valid_to >= NOW();');
-        if (is_bool($resultToken)) {
+            . 'group_activation_tokens` WHERE LOWER(token) = LOWER("' . $escapedToken
+            . '") AND valid_from <= NOW() AND valid_to >= NOW() LIMIT 1;');
+        if ($resultToken === false) {
             throw new DbmsException('Db expected.');
         }
-        $tokenData = $resultToken->fetch_assoc(); // fetch first row, it should be the only one, anyway
-        Debugger::barDump($tokenData, 'tokenData');
+        $tokenData = $resultToken->fetch_assoc(); // fetch first row
+        // Debug information removed; return wrong token status when not found.
         if (!$tokenData) {
             return self::ACTIVATION_WRONG_TOKEN;
         }

--- a/src/GroupManager.php
+++ b/src/GroupManager.php
@@ -69,8 +69,10 @@ class GroupManager
         if ($resultToken === false) {
             throw new DbmsException('Db expected.');
         }
+        // Ensure static analyzers know we have a mysqli_result here
+        Assert::isInstanceOf($resultToken, \mysqli_result::class);
         $tokenData = $resultToken->fetch_assoc(); // fetch first row
-        // Debug information removed; return wrong token status when not found.
+        // Return wrong token status when not found.
         if (!$tokenData) {
             return self::ACTIVATION_WRONG_TOKEN;
         }

--- a/src/GroupManager.php
+++ b/src/GroupManager.php
@@ -51,7 +51,7 @@ class GroupManager
      * following responses:
      *  - wrong token / already activated / new activation
      *
-     * TODO: the $token comparison is case-insensitive. Make it explicit.
+     * Token comparison is intentionally case-insensitive.
      *
      * @param string $token
      * @return int self::ACTIVATION constant mimicking the HTTP response codes

--- a/src/IdentityManager.php
+++ b/src/IdentityManager.php
@@ -500,7 +500,7 @@ class IdentityManager implements IdentityManagerInterface
     /**
      * Cookie path injection.
      *
-     * As '' may change (between /app and /app/user) causing cookie conflicts.
+     * As the default relative path '' may change (between /app and /app/user) causing cookie conflicts.
      *
      * @param string $cookiePath
      * @return void

--- a/src/IdentityManager.php
+++ b/src/IdentityManager.php
@@ -307,6 +307,11 @@ class IdentityManager implements IdentityManagerInterface
         if (is_null($row)) {
             return null;
         }
+        $userId = (int) $row['user_id'];
+        $setQueryLogUser = [$this->mysqli, 'setUser'];
+        if (is_callable($setQueryLogUser)) {
+            call_user_func($setQueryLogUser, $userId);
+        }
         // Update last access when the saved timestamp is stale enough.
         Debugger::barDump($row, 'User for session'); // debug
         $fiveMinutesAgo = date('Y-m-d H:i:s', time() - 300);
@@ -318,7 +323,7 @@ class IdentityManager implements IdentityManagerInterface
         } else {
             Debugger::barDump('No session update as younger than 5 minutes');
         }
-        return (int) $row['user_id'];
+        return $userId;
     }
 
     /**

--- a/src/IdentityManager.php
+++ b/src/IdentityManager.php
@@ -110,11 +110,11 @@ class IdentityManager implements IdentityManagerInterface
         }
     }
 
-private function deleteSessionToken(string $token): void
+    private function deleteSessionToken(string $token): void
     {
-  $this->mysqli->query("DELETE FROM `{$this->tablePrefix}session_user` WHERE token = '" . $token . "';");
+        $this->mysqli->query("DELETE FROM `{$this->tablePrefix}session_user` WHERE token = '" . $token . "';");
     }
-    
+
     /**
      * Checks if the Remember Me cookie matches.
      *

--- a/src/IdentityManager.php
+++ b/src/IdentityManager.php
@@ -16,15 +16,15 @@ use Webmozart\Assert\Assert;
  * IdentityManager class manages user authentication and session handling.
  * Uses MySQLi for database access.
  *
- * Call setTablePrefix injection, if table prefix is used.
+ * Inject a table prefix with setTablePrefix() when the application uses prefixed auth tables.
  *
- * Sets 'sbRememberMe' cookie = Remember Me cookie = RM cookie
+ * Sets the 'sbRememberMe' cookie when Remember Me is enabled and the request is HTTPS.
  *
  * Note: Timestamps and Timezones: Ensure that your PHP and MySQL timezones are properly set,
  * as the code uses CURRENT_TIMESTAMP for time-related operations.
- * TODO: not just (string) type casting but also escapeSQL against SQL injection
+ * TODO: move mutable SQL statements to prepared statements.
  * TODO: test intervals and refactor code
- * TODO: Pdo as well as Mysqli
+ * TODO: PDO as well as MySQLi.
  */
 class IdentityManager implements IdentityManagerInterface
 {
@@ -34,12 +34,12 @@ class IdentityManager implements IdentityManagerInterface
     private $cookiePath = '';
     /** @var string User email. */
     private $email;
-    /** x@ var bool Authentication status. */
-    //private $isAuthenticated = false;
     /** @var ?bool Flag indicating if the user trying to authenticate is a new user. */
     private $isNewUser = null;
     /** @var \mysqli Database connection. */
     private $mysqli;
+    /** @var bool Flag indicating whether the Remember Me cookie can be created and read. */
+    private $rememberMeCookieEnabled = true;
     /** @var int Role ID of the user. */
     private $roleId;
     /** @var string Table prefix for SQL queries. */
@@ -67,7 +67,7 @@ class IdentityManager implements IdentityManagerInterface
     {
         // Validate existence of the user or create it
         // Select email From users and if nothing returned, then INSERT email INTO users
-        // (Note never loggedin users older than 15 minutes are destroyed) <- TODO
+        // TODO destroy never-logged-in users older than 15 minutes.
         // Validate email format. Throwing the generic InvalidArgumentException from Webmozart is acceptable
         // for now; tests can catch it specifically if desired.
         Assert::email($email);
@@ -81,8 +81,10 @@ class IdentityManager implements IdentityManagerInterface
         // Ensure static analyzers know we have a mysqli_result here
         Assert::isInstanceOf($result, \mysqli_result::class);
         if ($result->num_rows === 0) {
-            $this->mysqli->query("INSERT INTO `{$this->tablePrefix}users` (email, created) VALUES ('" . $escapedEmail
-                . "', CURRENT_TIMESTAMP);"); // todo assert insert doesn't fail
+            $this->executeWriteQuery(
+                "INSERT INTO `{$this->tablePrefix}users` (email, created) VALUES ('" . $escapedEmail
+                . "', CURRENT_TIMESTAMP);"
+            );
             // Note: If the number is greater than maximal int value, mysqli_insert_id() will return a string.
             $this->userId = (int) $this->mysqli->insert_id;
             $this->isNewUser = true;
@@ -94,26 +96,37 @@ class IdentityManager implements IdentityManagerInterface
     /**
      * Creates a session ID and a remember-me token.
      *
-     * TODO consider insert also type (short session, long remember me) for selective purge
+     * TODO consider inserting token type (short session, long Remember Me) for selective purge.
      *
      * @param int $userId The user's ID.
      */
     private function createSessionId(int $userId): void
     {
-        // insert uniqid to the sessionId field and userId into userId field of the session_user table
-        $sessionId = uniqid('', true); // todo maybe also generateToken()???
-        $rememberMeToken = $this->generateToken();
-        $this->mysqli->query("INSERT INTO `{$this->tablePrefix}session_user` (user_id, token, updated) VALUES ("
-            . (int) $userId . ", '" . $sessionId . "', CURRENT_TIMESTAMP), (" . (int) $userId
-            . ", '" . $rememberMeToken . "', CURRENT_TIMESTAMP);");
-        // todo assert insert doesn't fail
+        // Insert a short-lived session token and, when enabled over HTTPS, a long-lived Remember Me token.
+        $sessionId = $this->generateToken();
+        $values = [
+            "(" . (int) $userId . ", '" . $this->mysqli->real_escape_string($sessionId) . "', CURRENT_TIMESTAMP)"
+        ];
+        $rememberMeToken = null;
+        $shouldCreateRememberMe = $this->rememberMeCookieEnabled && $this->isHttps($_SERVER);
+        if ($shouldCreateRememberMe) {
+            $rememberMeToken = $this->generateToken();
+            $values[] = "(" . (int) $userId . ", '" . $this->mysqli->real_escape_string($rememberMeToken)
+                . "', CURRENT_TIMESTAMP)";
+        }
+        $this->executeWriteQuery(
+            "INSERT INTO `{$this->tablePrefix}session_user` (user_id, token, updated) VALUES "
+            . implode(', ', $values) . ";"
+        );
         $_SESSION['sbSessionToken'] = $sessionId;
         // Create a long-lived relogin cookie which expires in 30 days (only for HTTPS)
-        if ($this->isHttps($_SERVER)) {
+        if ($rememberMeToken !== null) {
             $this->setCookie(
                 $rememberMeToken,
                 time() + 30 * 24 * 60 * 60 // expire time: days * hours * minutes * seconds
             );
+        } elseif (!$this->rememberMeCookieEnabled) {
+            Debugger::barDump('sbRememberMe cookie disabled');
         } else {
             Debugger::barDump('http => no sbRememberMe cookie');
         }
@@ -121,7 +134,10 @@ class IdentityManager implements IdentityManagerInterface
 
     private function deleteSessionToken(string $token): void
     {
-        $this->mysqli->query("DELETE FROM `{$this->tablePrefix}session_user` WHERE token = '" . $token . "';");
+        $this->executeWriteQuery(
+            "DELETE FROM `{$this->tablePrefix}session_user` WHERE token = '"
+            . $this->mysqli->real_escape_string($token) . "';"
+        );
     }
 
     /**
@@ -132,6 +148,9 @@ class IdentityManager implements IdentityManagerInterface
      */
     public function doYouRememberMe(array $cookie): bool
     {
+        if (!$this->rememberMeCookieEnabled) {
+            return false;
+        }
         // Check if the "Remember Me" cookie exists
         if (!isset($cookie['sbRememberMe'])) {
             return false;
@@ -146,16 +165,30 @@ class IdentityManager implements IdentityManagerInterface
             return false;
         }
         // delete the old cookie id from session_user as new one will be set in createSessionId anyway
-        $this->mysqli->query("DELETE FROM `{$this->tablePrefix}session_user` WHERE user_id = " . $userId
+        $this->executeWriteQuery("DELETE FROM `{$this->tablePrefix}session_user` WHERE user_id = " . $userId
             . " AND token = '" . $this->mysqli->real_escape_string($cookie['sbRememberMe']) . "';");
         $this->createSessionId($userId); // incidentally also updates the RM cookie
         return true;
     }
 
     /**
+     * Executes a write query and throws on database errors.
+     *
+     * @param string $query SQL query string.
+     * @return void
+     * @throws DbmsException on database statement error
+     */
+    private function executeWriteQuery(string $query): void
+    {
+        if ($this->mysqli->query($query) !== true) {
+            throw new DbmsException($this->mysqli->errno . ': ' . $this->mysqli->error);
+        }
+    }
+
+    /**
      * Fetches the first row of a query result.
      *
-     * TODO: add ORDER BY to queries, and as there's a LIMIT 1, get rid off this method, use queryStrict
+     * TODO add ORDER BY to queries, and as there is a LIMIT 1, replace this method with queryStrict.
      *
      * @param string $query SQL query string.
      * @return array<?scalar>|null Associative array of the row or null if no rows.
@@ -179,7 +212,7 @@ class IdentityManager implements IdentityManagerInterface
     /**
      * Generates a unique token for user sessions or actions.
      *
-     * TODO next phase - CSRF token method used
+     * TODO next phase - use a CSRF token method.
      *
      * @return string A hexadecimal token string.
      */
@@ -226,7 +259,7 @@ class IdentityManager implements IdentityManagerInterface
     public function getRoleId(): int
     {
         if (empty($this->roleId)) {
-            throw new UserException('You should first check the existence of User.'); // todo check it really here?
+            throw new UserException('You should first check the existence of User.'); // TODO check it really here?
         }
         return $this->roleId;
     }
@@ -271,8 +304,10 @@ class IdentityManager implements IdentityManagerInterface
         // Update last access
         // TODO prolongate session only if the previous access is older than 5 minutes to reduce SQL load
         Debugger::barDump($row, 'User for session'); // debug
-        $this->mysqli->query("UPDATE `{$this->tablePrefix}session_user` SET updated = CURRENT_TIMESTAMP WHERE token = '"
-            . $sessionTokenEscaped . "';");
+        $this->executeWriteQuery(
+            "UPDATE `{$this->tablePrefix}session_user` SET updated = CURRENT_TIMESTAMP WHERE token = '"
+            . $sessionTokenEscaped . "';"
+        );
         return (int) $row['user_id'];
     }
 
@@ -289,7 +324,7 @@ class IdentityManager implements IdentityManagerInterface
         $userId = is_string($sessionId) ? $this->getUserForSessionId($sessionId) : null;
 
         if ($userId === null) {
-            // todo doYouRememberMe?
+            // TODO doYouRememberMe?
             return false;
         }
 
@@ -361,18 +396,23 @@ class IdentityManager implements IdentityManagerInterface
      */
     public function isTokenValid(string $emailToken): bool
     {
+        $emailTokenEscaped = $this->mysqli->real_escape_string($emailToken);
         $row = $this->fetchFirstRow(
-            "SELECT id, email FROM `{$this->tablePrefix}email_token` WHERE token = '" . $emailToken
+            "SELECT id, email FROM `{$this->tablePrefix}email_token` WHERE token = '" . $emailTokenEscaped
             . "' AND created > (NOW() - INTERVAL 15 MINUTE) LIMIT 1;"
         );
         if (is_null($row)) {
             return false;
         }
         // Token is one time only
-        $this->mysqli->query("DELETE FROM `{$this->tablePrefix}email_token` WHERE id = " . (int) $row['id'] . ";");
+        $this->executeWriteQuery(
+            "DELETE FROM `{$this->tablePrefix}email_token` WHERE id = " . (int) $row['id'] . ";"
+        );
          // Update last_access
-        $this->mysqli->query("UPDATE `{$this->tablePrefix}users` SET last_login = CURRENT_TIMESTAMP WHERE email = '"
-            . (string) $row['email'] . "';");
+        $this->executeWriteQuery(
+            "UPDATE `{$this->tablePrefix}users` SET last_login = CURRENT_TIMESTAMP WHERE email = '"
+            . $this->mysqli->real_escape_string((string) $row['email']) . "';"
+        );
 
         $this->populateUserByEmail((string) $row['email']);
         return true;
@@ -381,7 +421,7 @@ class IdentityManager implements IdentityManagerInterface
     /**
      * Logic for the user login. Validate email and return a token to be sent by email.
      *
-     * TODO allow inserting the token to an HTML input field.
+     * TODO allow inserting the token into an HTML input field.
      *
      * @param string $email
      * @return string
@@ -391,9 +431,9 @@ class IdentityManager implements IdentityManagerInterface
         $this->checkEmailOrCreateUser($email);
         $token = $this->generateToken();
         // Generate and store a token for this email
-        $this->mysqli->query("INSERT INTO `{$this->tablePrefix}email_token` (email, token, created) VALUES ('"
-            . (string) $email . "', '" . (string) $token . "', CURRENT_TIMESTAMP);");
-        // todo assert insert doesn't fail
+        $this->executeWriteQuery("INSERT INTO `{$this->tablePrefix}email_token` (email, token, created) VALUES ('"
+            . $this->mysqli->real_escape_string($email) . "', '" . $this->mysqli->real_escape_string($token)
+            . "', CURRENT_TIMESTAMP);");
         return $token;
     }
 
@@ -421,21 +461,18 @@ class IdentityManager implements IdentityManagerInterface
     public function logout(): void
     {
         Assert::string($_SESSION['sbSessionToken']);
-     //   $this->mysqli->query("DELETE FROM `{$this->tablePrefix}session_user` WHERE token = '"
-       //     . $_SESSION['sbSessionToken'] . "';");
+        // Delete through the helper so escaping and DB error handling stay consistent.
         $this->deleteSessionToken($_SESSION['sbSessionToken']);
         unset($_SESSION['sbSessionToken']);
-        // todo remove csrf tokens from this browser context
+        // TODO remove csrf tokens from this browser context.
         // Remove "Remember Me" cookie if it exists both from database and from cookies
         if (isset($_COOKIE['sbRememberMe'])) {
             Assert::string($_COOKIE['sbRememberMe']);
-        //    $this->mysqli->query("DELETE FROM `{$this->tablePrefix}session_user` WHERE token = '"
-        //        . (string) $_COOKIE['sbRememberMe'] . "';");
-                    $this->deleteSessionToken($_COOKIE['sbRememberMe']);
+            // Delete the Remember Me token through the same path as the short session token.
+            $this->deleteSessionToken($_COOKIE['sbRememberMe']);
             $this->setCookie('', time() - 3600);
         }
-        //$this->isAuthenticated = false;
-        //todo make sure that seablast knows, i.e. invalidate SB_ROLE_ID and USER_ID
+        // TODO make sure that Seablast knows, i.e. invalidate SB_ROLE_ID and USER_ID.
     }
 
     /**
@@ -450,7 +487,7 @@ class IdentityManager implements IdentityManagerInterface
     private function populateUserByEmail(string $email): void
     {
         $row = $this->fetchFirstRow("SELECT id, role_id FROM `{$this->tablePrefix}users` WHERE email = '"
-            . (string) $email . "' LIMIT 1;");
+            . $this->mysqli->real_escape_string($email) . "' LIMIT 1;");
         if (is_null($row)) {
             throw new UserException('An existing user expected.');
         }
@@ -524,6 +561,19 @@ class IdentityManager implements IdentityManagerInterface
     {
         $this->cookiePath = $cookiePath;
         Debugger::barDump($this->cookiePath, 'Injected cookie path to IdentityManager');
+    }
+
+    /**
+     * Remember Me cookie feature flag injection.
+     *
+     * Defaults to true for backwards compatibility with direct IdentityManager users.
+     *
+     * @param bool $enabled
+     * @return void
+     */
+    public function setRememberMeCookieEnabled(bool $enabled): void
+    {
+        $this->rememberMeCookieEnabled = $enabled;
     }
 
     /**

--- a/src/IdentityManager.php
+++ b/src/IdentityManager.php
@@ -34,8 +34,8 @@ class IdentityManager implements IdentityManagerInterface
     private $cookiePath = '';
     /** @var string User email. */
     private $email;
-    /** @var bool Authentication status. */
-    private $isAuthenticated = false;
+    /** x@ var bool Authentication status. */
+    //private $isAuthenticated = false;
     /** @var ?bool Flag indicating if the user trying to authenticate is a new user. */
     private $isNewUser = null;
     /** @var \mysqli Database connection. */
@@ -281,11 +281,11 @@ class IdentityManager implements IdentityManagerInterface
 
     if ($userId === null) {
         // todo doYouRememberMe?
-        return $this->isAuthenticated = false;
+        return false;
     }
 
     $this->populateUserById($userId);
-    return $this->isAuthenticated = true;
+    return true;
 }
 
     /**
@@ -425,7 +425,8 @@ class IdentityManager implements IdentityManagerInterface
                     $this->deleteSessionToken($_COOKIE['sbRememberMe']);
             $this->setCookie('', time() - 3600);
         }
-        $this->isAuthenticated = false;
+        //$this->isAuthenticated = false;
+        //todo make sure that seablast knows, i.e. invalidate SB_ROLE_ID and USER_ID
     }
 
     /**
@@ -465,7 +466,7 @@ class IdentityManager implements IdentityManagerInterface
     private function populateUserById(int $userId): void
     {
         $row = $this->fetchFirstRow("SELECT email, role_id FROM `{$this->tablePrefix}users` WHERE id = "
-            . (int) $userId . ";");
+            . (int) $userId . " LIMIT 1;");
         if (is_null($row)) {
             throw new UserException('An existing user expected.');
         }

--- a/src/IdentityManager.php
+++ b/src/IdentityManager.php
@@ -275,18 +275,18 @@ class IdentityManager implements IdentityManagerInterface
      * @return bool True if authenticated, false otherwise.
      */
     public function isAuthenticated(): bool
-{
-    $sessionId = $_SESSION['sbSessionToken'] ?? null;
-    $userId = is_string($sessionId) ? $this->getUserForSessionId($sessionId) : null;
+    {
+        $sessionId = $_SESSION['sbSessionToken'] ?? null;
+        $userId = is_string($sessionId) ? $this->getUserForSessionId($sessionId) : null;
 
-    if ($userId === null) {
-        // todo doYouRememberMe?
-        return false;
+        if ($userId === null) {
+            // todo doYouRememberMe?
+            return false;
+        }
+
+        $this->populateUserById($userId);
+        return true;
     }
-
-    $this->populateUserById($userId);
-    return true;
-}
 
     /**
      * Checks whether the current request was made using HTTPS.

--- a/src/IdentityManager.php
+++ b/src/IdentityManager.php
@@ -308,6 +308,7 @@ class IdentityManager implements IdentityManagerInterface
             return null;
         }
         $userId = (int) $row['user_id'];
+        // Set the query-log user immediately after resolving `user_id`, before refreshing `session_user.updated`
         $setQueryLogUser = [$this->mysqli, 'setUser'];
         if (is_callable($setQueryLogUser)) {
             call_user_func($setQueryLogUser, $userId);

--- a/src/IdentityManager.php
+++ b/src/IdentityManager.php
@@ -68,11 +68,13 @@ class IdentityManager implements IdentityManagerInterface
         // Validate existence of the user or create it
         // Select email From users and if nothing returned, then INSERT email INTO users
         // (Note never loggedin users older than 15 minutes are destroyed) <- TODO
-        Assert::email($email); // TODO more specific Exception to catch exactly it in a PHPUnit test
-        $result = $this->mysqli->query("SELECT email FROM `{$this->tablePrefix}users` WHERE email = '"
-            . (string) $email . "';");
-        if (is_bool($result) || !$result->fetch_assoc()) {
-            $this->mysqli->query("INSERT INTO `{$this->tablePrefix}users` (email, created) VALUES ('" . (string) $email
+        // Validate email format. Throwing the generic InvalidArgumentException from Webmozart is acceptable
+        // for now; tests can catch it specifically if desired.
+        Assert::email($email);
+        $escapedEmail = $this->mysqli->real_escape_string($email);
+        $result = $this->mysqli->query("SELECT email FROM `{$this->tablePrefix}users` WHERE email = '" . $escapedEmail . "' LIMIT 1;");
+        if ($result === false || $result->num_rows === 0) {
+            $this->mysqli->query("INSERT INTO `{$this->tablePrefix}users` (email, created) VALUES ('" . $escapedEmail
                 . "', CURRENT_TIMESTAMP);"); // todo assert insert doesn't fail
             // Note: If the number is greater than maximal int value, mysqli_insert_id() will return a string.
             $this->userId = (int) $this->mysqli->insert_id;

--- a/src/IdentityManager.php
+++ b/src/IdentityManager.php
@@ -110,6 +110,11 @@ class IdentityManager implements IdentityManagerInterface
         }
     }
 
+private function deleteSessionToken(string $token): void
+    {
+  $this->mysqli->query("DELETE FROM `{$this->tablePrefix}session_user` WHERE token = '" . $token . "';");
+    }
+    
     /**
      * Checks if the Remember Me cookie matches.
      *
@@ -409,15 +414,17 @@ class IdentityManager implements IdentityManagerInterface
     public function logout(): void
     {
         Assert::string($_SESSION['sbSessionToken']);
-        $this->mysqli->query("DELETE FROM `{$this->tablePrefix}session_user` WHERE token = '"
-            . $_SESSION['sbSessionToken'] . "';");
+     //   $this->mysqli->query("DELETE FROM `{$this->tablePrefix}session_user` WHERE token = '"
+       //     . $_SESSION['sbSessionToken'] . "';");
+        $this->deleteSessionToken($_SESSION['sbSessionToken']);
         unset($_SESSION['sbSessionToken']);
         // todo remove csrf tokens from this browser context
         // Remove "Remember Me" cookie if it exists both from database and from cookies
         if (isset($_COOKIE['sbRememberMe'])) {
             Assert::string($_COOKIE['sbRememberMe']);
-            $this->mysqli->query("DELETE FROM `{$this->tablePrefix}session_user` WHERE token = '"
-                . (string) $_COOKIE['sbRememberMe'] . "';");
+        //    $this->mysqli->query("DELETE FROM `{$this->tablePrefix}session_user` WHERE token = '"
+        //        . (string) $_COOKIE['sbRememberMe'] . "';");
+                    $this->deleteSessionToken($_COOKIE['sbRememberMe']);
             $this->setCookie('', time() - 3600);
         }
         $this->isAuthenticated = false;

--- a/src/IdentityManager.php
+++ b/src/IdentityManager.php
@@ -72,7 +72,9 @@ class IdentityManager implements IdentityManagerInterface
         // for now; tests can catch it specifically if desired.
         Assert::email($email);
         $escapedEmail = $this->mysqli->real_escape_string($email);
-        $result = $this->mysqli->query("SELECT email FROM `{$this->tablePrefix}users` WHERE email = '" . $escapedEmail . "' LIMIT 1;");
+        $query = "SELECT email FROM `{$this->tablePrefix}users` WHERE email = '" . $escapedEmail
+            . "' LIMIT 1;";
+        $result = $this->mysqli->query($query);
         if ($result === false) {
             throw new DbmsException($this->mysqli->errno . ': ' . $this->mysqli->error);
         }

--- a/src/IdentityManager.php
+++ b/src/IdentityManager.php
@@ -146,6 +146,8 @@ class IdentityManager implements IdentityManagerInterface
     /**
      * Fetches the first row of a query result.
      *
+     * TODO: add ORDER BY to queries, and as there's a LIMIT 1, get rid off this method, use queryStrict
+     *
      * @param string $query SQL query string.
      * @return array<?scalar>|null Associative array of the row or null if no rows.
      * @throws DbmsException on database statement error
@@ -253,7 +255,7 @@ class IdentityManager implements IdentityManagerInterface
         $pastDate = $oneDayTillNow->format('Y-m-d H:i:s');
         Debugger::barDump($pastDate, 'Past date'); // debug
         $row = $this->fetchFirstRow("SELECT user_id, updated FROM `{$this->tablePrefix}session_user` WHERE token = '"
-            . $sessionTokenEscaped . "' AND updated > '" . $pastDate . "';");
+            . $sessionTokenEscaped . "' AND updated > '" . $pastDate . "' LIMIT 1;");
         if (is_null($row)) {
             return null;
         }
@@ -273,22 +275,18 @@ class IdentityManager implements IdentityManagerInterface
      * @return bool True if authenticated, false otherwise.
      */
     public function isAuthenticated(): bool
-    {
-        $sessionId = $_SESSION['sbSessionToken'] ?? null;
-        if (is_null($sessionId) || !is_string($sessionId)) {
-            // todo doYouRememberMe?
-            $this->isAuthenticated = false;
-        } else {
-            $userId = $this->getUserForSessionId($sessionId);
-            if (is_null($userId)) {
-                $this->isAuthenticated = false;
-            } else {
-                $this->isAuthenticated = true;
-                $this->populateUserById($userId);
-            }
-        }
-        return $this->isAuthenticated;
+{
+    $sessionId = $_SESSION['sbSessionToken'] ?? null;
+    $userId = is_string($sessionId) ? $this->getUserForSessionId($sessionId) : null;
+
+    if ($userId === null) {
+        // todo doYouRememberMe?
+        return $this->isAuthenticated = false;
     }
+
+    $this->populateUserById($userId);
+    return $this->isAuthenticated = true;
+}
 
     /**
      * Checks whether the current request was made using HTTPS.
@@ -356,7 +354,7 @@ class IdentityManager implements IdentityManagerInterface
     {
         $row = $this->fetchFirstRow(
             "SELECT id, email FROM `{$this->tablePrefix}email_token` WHERE token = '" . $emailToken
-            . "' AND created > (NOW() - INTERVAL 15 MINUTE);"
+            . "' AND created > (NOW() - INTERVAL 15 MINUTE) LIMIT 1;"
         );
         if (is_null($row)) {
             return false;
@@ -442,7 +440,7 @@ class IdentityManager implements IdentityManagerInterface
     private function populateUserByEmail(string $email): void
     {
         $row = $this->fetchFirstRow("SELECT id, role_id FROM `{$this->tablePrefix}users` WHERE email = '"
-            . (string) $email . "';");
+            . (string) $email . "' LIMIT 1;");
         if (is_null($row)) {
             throw new UserException('An existing user expected.');
         }

--- a/src/IdentityManager.php
+++ b/src/IdentityManager.php
@@ -73,7 +73,12 @@ class IdentityManager implements IdentityManagerInterface
         Assert::email($email);
         $escapedEmail = $this->mysqli->real_escape_string($email);
         $result = $this->mysqli->query("SELECT email FROM `{$this->tablePrefix}users` WHERE email = '" . $escapedEmail . "' LIMIT 1;");
-        if ($result === false || $result->num_rows === 0) {
+        if ($result === false) {
+            throw new DbmsException($this->mysqli->errno . ': ' . $this->mysqli->error);
+        }
+        // Ensure static analyzers know we have a mysqli_result here
+        Assert::isInstanceOf($result, \mysqli_result::class);
+        if ($result->num_rows === 0) {
             $this->mysqli->query("INSERT INTO `{$this->tablePrefix}users` (email, created) VALUES ('" . $escapedEmail
                 . "', CURRENT_TIMESTAMP);"); // todo assert insert doesn't fail
             // Note: If the number is greater than maximal int value, mysqli_insert_id() will return a string.

--- a/src/IdentityManager.php
+++ b/src/IdentityManager.php
@@ -301,13 +301,17 @@ class IdentityManager implements IdentityManagerInterface
         if (is_null($row)) {
             return null;
         }
-        // Update last access
-        // TODO prolongate session only if the previous access is older than 5 minutes to reduce SQL load
+        // Update last access when the saved timestamp is stale enough.
         Debugger::barDump($row, 'User for session'); // debug
-        $this->executeWriteQuery(
-            "UPDATE `{$this->tablePrefix}session_user` SET updated = CURRENT_TIMESTAMP WHERE token = '"
-            . $sessionTokenEscaped . "';"
-        );
+        $fiveMinutesAgo = date('Y-m-d H:i:s', time() - 300);
+        if ((string) $row['updated'] < $fiveMinutesAgo) {
+            $this->executeWriteQuery(
+                "UPDATE `{$this->tablePrefix}session_user` SET updated = CURRENT_TIMESTAMP WHERE token = '"
+                . $sessionTokenEscaped . "';"
+            );
+        } else {
+            Debugger::barDump('No session update as younger than 5 minutes');
+        }
         return (int) $row['user_id'];
     }
 

--- a/src/IdentityManager.php
+++ b/src/IdentityManager.php
@@ -191,7 +191,7 @@ class IdentityManager implements IdentityManagerInterface
      *
      * Implementation of Seablast\Seablast\IdentityManagerInterface.
      *
-     * @return int[] An array of group IDs.
+     * @return array<int> An array of group IDs.
      */
     public function getGroups(): array
     {

--- a/src/IdentityManager.php
+++ b/src/IdentityManager.php
@@ -65,9 +65,15 @@ class IdentityManager implements IdentityManagerInterface
      */
     private function checkEmailOrCreateUser(string $email): void
     {
+        // remove never-logged-in users older than 15 minutes (could be triggered by cron instead)
+        $this->executeWriteQuery(
+            "DELETE u FROM `{$this->tablePrefix}users` AS u WHERE u.last_login IS NULL"
+            . " AND u.created < (CURRENT_TIMESTAMP - INTERVAL 15 MINUTE)"
+            . " AND NOT EXISTS (SELECT 1 FROM `{$this->tablePrefix}session_user` AS su"
+            . " WHERE su.user_id = u.id LIMIT 1);"
+        );
         // Validate existence of the user or create it
         // Select email From users and if nothing returned, then INSERT email INTO users
-        // TODO destroy never-logged-in users older than 15 minutes.
         // Validate email format. Throwing the generic InvalidArgumentException from Webmozart is acceptable
         // for now; tests can catch it specifically if desired.
         Assert::email($email);

--- a/src/Models/ApiSocialLoginModel.php
+++ b/src/Models/ApiSocialLoginModel.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Seablast\Auth\Models;
 
+use Seablast\Auth\AuthConstant;
 use Seablast\Auth\IdentityManager;
 use Seablast\Seablast\Apis\GenericRestApiJsonModel;
 use Seablast\Seablast\SeablastConfiguration;
@@ -58,6 +59,9 @@ class ApiSocialLoginModel extends GenericRestApiJsonModel
             $this->identity->setCookiePath(
                 $this->configuration->getString(SeablastConstant::SB_SESSION_SET_COOKIE_PARAMS_PATH)
             );
+            $this->identity->setRememberMeCookieEnabled(
+                $this->configuration->flag->status(AuthConstant::FLAG_REMEMBER_ME_COOKIE)
+            );
             // Business logic starts here
             // If logged in, log out first
             if ($this->identity->isAuthenticated()) {
@@ -66,7 +70,7 @@ class ApiSocialLoginModel extends GenericRestApiJsonModel
 
             $this->executeBusinessLogic();
             Assert::propertyExists($result, 'rest');
-            Assert::isInstanceOf($result->rest, \stdClass::class);  // …and `rest` is an object
+            Assert::isInstanceOf($result->rest, \stdClass::class); // and `rest` is an object
             $result->rest->message = $this->message;
             $result->httpCode = $this->httpCode;
             if ($this->httpCode === 200) {
@@ -127,30 +131,29 @@ class ApiSocialLoginModel extends GenericRestApiJsonModel
                 return;
         }
         $payload = $this->socialProvider->authTokenToPayload($authToken);
-        $this->processPayloadEmail($payload, $authToken, 'Login successful - ' . $provider);
+        $this->processPayloadEmail($payload, 'Login successful - ' . $provider);
     }
 
     /**
      * Arrange login based on $payload['email'] which should contain the user's email.
      *
      * @param array<mixed>|false|null $payload
-     * @param string $authToken Just for logging problems
      * @param string $okMessage
      * @return void
      */
-    private function processPayloadEmail($payload, string $authToken, string $okMessage): void
+    private function processPayloadEmail($payload, string $okMessage): void
     {
         $this->message = 'Internal login failed';
         $this->httpCode = 500;
-        if (is_null($payload)) {
-            Debugger::barDump($authToken, 'Invalid ID token');
-            Debugger::log('Invalid ID token: ' . $authToken, ILogger::ERROR);
+        if ($payload === null || $payload === false) {
+            Debugger::barDump('Invalid social login ID token');
+            Debugger::log('Invalid social login ID token.', ILogger::ERROR);
             $this->message = 'Invalid ID token';
             $this->httpCode = 403;
             return;
         } elseif (!isset($payload['email']) || empty($payload['email'])) {
-            Debugger::barDump($authToken, 'Missing email for token');
-            Debugger::log('Missing email for ID token: ' . $authToken, ILogger::ERROR);
+            Debugger::barDump('Missing email for social login ID token');
+            Debugger::log('Missing email for social login ID token.', ILogger::ERROR);
             $this->message = 'Missing email for ID token';
             $this->httpCode = 401;
             return;

--- a/src/Models/SocialLoginGoogle.php
+++ b/src/Models/SocialLoginGoogle.php
@@ -61,19 +61,22 @@ class SocialLoginGoogle
         if ($response->getStatusCode() === 200) {
             $data = json_decode($response->getBody()->getContents(), true);
             // Response conforms to https://github.com/firebase/php-jwt
-            // Validate the audience, issuer, etc.
-            // TODO check also $data['exp']
+            // Validate the audience, issuer, and expiration if present.
             if ($data === false || !is_array($data)) {
                 Debugger::barDump($response->getBody()->getContents(), "Unexpected API response");
-            } elseif (
-                $data['aud'] === $this->configuration->getString(AuthConstant::GOOGLE_CLIENT_ID) &&
-                $data['iss'] === 'https://accounts.google.com'
-            ) {
-                //echo "Token is valid. User information:";
-                Assert::allString($data);
-                return $data;
             } else {
-                Debugger::barDump($data, 'Token is invalid or audience does not match.');
+                $isAudValid = ($data['aud'] === $this->configuration->getString(AuthConstant::GOOGLE_CLIENT_ID));
+                $isIssValid = ($data['iss'] === 'https://accounts.google.com' || $data['iss'] === 'accounts.google.com');
+                $isExpValid = true;
+                if (isset($data['exp'])) {
+                    // exp is in seconds since epoch
+                    $isExpValid = (is_numeric($data['exp']) && (int) $data['exp'] > time());
+                }
+                if ($isAudValid && $isIssValid && $isExpValid) {
+                    Assert::allString($data);
+                    return $data;
+                }
+                Debugger::barDump($data, 'Token is invalid, audience/issuer mismatch or expired.');
             }
         } else {
             Debugger::barDump(

--- a/src/Models/SocialLoginGoogle.php
+++ b/src/Models/SocialLoginGoogle.php
@@ -66,7 +66,10 @@ class SocialLoginGoogle
                 Debugger::barDump($response->getBody()->getContents(), "Unexpected API response");
             } else {
                 $isAudValid = ($data['aud'] === $this->configuration->getString(AuthConstant::GOOGLE_CLIENT_ID));
-                $isIssValid = ($data['iss'] === 'https://accounts.google.com' || $data['iss'] === 'accounts.google.com');
+                $isIssValid = (
+                    $data['iss'] === 'https://accounts.google.com'
+                    || $data['iss'] === 'accounts.google.com'
+                );
                 $isExpValid = true;
                 if (isset($data['exp'])) {
                     // exp is in seconds since epoch

--- a/src/Models/SocialLoginGoogle.php
+++ b/src/Models/SocialLoginGoogle.php
@@ -5,10 +5,11 @@ declare(strict_types=1);
 namespace Seablast\Auth\Models;
 
 use GuzzleHttp\Client;
+use GuzzleHttp\ClientInterface;
 use Seablast\Auth\AuthConstant;
 use Seablast\Seablast\SeablastConfiguration;
 use Tracy\Debugger;
-use Webmozart\Assert\Assert;
+use Tracy\ILogger;
 
 /**
  * API receives social token and retrieves email.
@@ -24,13 +25,17 @@ class SocialLoginGoogle
 
     /** @var SeablastConfiguration */
     protected $configuration;
+    /** @var ClientInterface */
+    private $client;
 
     /**
      * @param SeablastConfiguration $configuration
+     * @param ClientInterface|null $client
      */
-    public function __construct(SeablastConfiguration $configuration)
+    public function __construct(SeablastConfiguration $configuration, ?ClientInterface $client = null)
     {
         $this->configuration = $configuration;
+        $this->client = $client ?: new Client();
     }
 
     /**
@@ -42,7 +47,7 @@ class SocialLoginGoogle
      * which is located in the https://github.com/googleapis/google-api-php-client repository.
      *
      * @param string $idToken
-     * @return array<string>|false
+     * @return array<string,string>|false
      */
     public function authTokenToPayload(string $idToken)
     {
@@ -53,43 +58,90 @@ class SocialLoginGoogle
         if (!$this->configuration->exists(AuthConstant::GOOGLE_CLIENT_ID)) {
             return false;
         }
-        $client = new Client();
-        $response = $client->get('https://oauth2.googleapis.com/tokeninfo', [
-            'query' => ['id_token' => $idToken]
-        ]);
+        try {
+            $response = $this->client->request('GET', 'https://oauth2.googleapis.com/tokeninfo', [
+                'http_errors' => false,
+                'query' => ['id_token' => $idToken]
+            ]);
+        } catch (\Exception $e) {
+            Debugger::log('Google tokeninfo request failed: ' . get_class($e), ILogger::ERROR);
+            return false;
+        }
 
         if ($response->getStatusCode() === 200) {
-            $data = json_decode($response->getBody()->getContents(), true);
+            $body = $response->getBody()->getContents();
+            $data = $this->normalizePayload(json_decode($body, true));
             // Response conforms to https://github.com/firebase/php-jwt
-            // Validate the audience, issuer, and expiration if present.
-            if ($data === false || !is_array($data)) {
-                Debugger::barDump($response->getBody()->getContents(), "Unexpected API response");
+            // Validate the audience, issuer, email, and expiration if present.
+            if (is_null($data)) {
+                Debugger::barDump(json_last_error_msg(), "Unexpected Google tokeninfo response");
+            } elseif ($this->isValidPayload($data)) {
+                return $data;
             } else {
-                $isAudValid = ($data['aud'] === $this->configuration->getString(AuthConstant::GOOGLE_CLIENT_ID));
-                $isIssValid = (
-                    $data['iss'] === 'https://accounts.google.com'
-                    || $data['iss'] === 'accounts.google.com'
+                Debugger::barDump(
+                    [
+                        'audienceMatches' => isset($data['aud'])
+                            && $data['aud'] === $this->configuration->getString(AuthConstant::GOOGLE_CLIENT_ID),
+                        'issuer' => $data['iss'] ?? null,
+                        'hasEmail' => !empty($data['email']),
+                        'hasExpiration' => isset($data['exp'])
+                    ],
+                    'Google tokeninfo payload did not pass validation.'
                 );
-                $isExpValid = true;
-                if (isset($data['exp'])) {
-                    // exp is in seconds since epoch
-                    $isExpValid = (is_numeric($data['exp']) && (int) $data['exp'] > time());
-                }
-                if ($isAudValid && $isIssValid && $isExpValid) {
-                    Assert::allString($data);
-                    return $data;
-                }
-                Debugger::barDump($data, 'Token is invalid, audience/issuer mismatch or expired.');
             }
         } else {
             Debugger::barDump(
                 [
-                    'idToken' => $idToken,
+                    'statusCode' => $response->getStatusCode(),
                     'GOOGLE_CLIENT_ID' => $this->configuration->getString(AuthConstant::GOOGLE_CLIENT_ID)
                 ],
-                'Failed to validate token.'
+                'Google tokeninfo request failed.'
             );
         }
         return false;
+    }
+
+    /**
+     * Validate required Google tokeninfo payload fields.
+     *
+     * @param array<string,string> $data
+     * @return bool
+     */
+    private function isValidPayload(array $data): bool
+    {
+        if (
+            !isset($data['aud'], $data['iss'], $data['email']) ||
+            $data['aud'] !== $this->configuration->getString(AuthConstant::GOOGLE_CLIENT_ID) ||
+            !in_array($data['iss'], ['https://accounts.google.com', 'accounts.google.com'], true) ||
+            filter_var($data['email'], FILTER_VALIDATE_EMAIL) === false
+        ) {
+            return false;
+        }
+        if (!isset($data['exp'])) {
+            return true;
+        }
+        // exp is in seconds since epoch.
+        return is_numeric($data['exp']) && (int) $data['exp'] > time();
+    }
+
+    /**
+     * Normalize tokeninfo JSON into a flat string array.
+     *
+     * @param mixed $data
+     * @return array<string,string>|null
+     */
+    private function normalizePayload($data): ?array
+    {
+        if (!is_array($data)) {
+            return null;
+        }
+        $output = [];
+        foreach ($data as $key => $value) {
+            if (!is_string($key) || !is_scalar($value)) {
+                return null;
+            }
+            $output[$key] = (string) $value;
+        }
+        return $output;
     }
 }

--- a/src/UserModel.php
+++ b/src/UserModel.php
@@ -55,10 +55,13 @@ class UserModel implements SeablastModelInterface
         $this->user->setCookiePath(
             $this->configuration->getString(SeablastConstant::SB_SESSION_SET_COOKIE_PARAMS_PATH)
         );
+        $this->user->setRememberMeCookieEnabled(
+            $this->configuration->flag->status(AuthConstant::FLAG_REMEMBER_ME_COOKIE)
+        );
     }
 
     /**
-     * Different reaction to different authentization state
+     * Different response for the current authentication state.
      * @return stdClass
      * @throw \Exception if unimplemented HTTP method call
      */
@@ -69,7 +72,7 @@ class UserModel implements SeablastModelInterface
                 $this->user->logout();
                 return (object) [
                         'redirectionUrl' => $this->configuration->getString(SeablastConstant::SB_APP_ROOT_ABSOLUTE_URL)
-                        . $this->userRoute, // Todo go home instead?
+                        . $this->userRoute, // TODO go home instead?
                 ];
             }
             return (object) [
@@ -91,7 +94,7 @@ class UserModel implements SeablastModelInterface
                     //    . ' <a href="../content-root">Moje kroniky</a>', // HTML is displayed escaped
                     //];
                     // ... so refresh the page ;-)
-                    // todo go to the original target insted of /user
+                    // TODO go to the original target instead of /user
                     return (object) [
                             'redirectionUrl' =>
                             $this->configuration->getString(SeablastConstant::SB_APP_ROOT_ABSOLUTE_URL)
@@ -122,7 +125,7 @@ class UserModel implements SeablastModelInterface
                         $this->configuration->getString(SeablastConstant::SB_APP_ROOT_ABSOLUTE_URL) . $this->userRoute,
                 ];
             }
-            // první přístup
+            // First visit
             return (object) [
                     'showLogin' => true,
                     'showLogout' => false,
@@ -186,7 +189,7 @@ class UserModel implements SeablastModelInterface
     private function sendLoginEmail(string $emailAddress, string $token): void
     {
         $loginUrl = $this->configuration->getString(SeablastConstant::SB_APP_ROOT_ABSOLUTE_URL)
-            . $this->userRoute . '/?token=' . $token; // TODO session should keep the original target URL - deep loging
+            . $this->userRoute . '/?token=' . $token; // TODO session should keep the original target URL - deep login
         Debugger::barDump($loginUrl, $this->user->isNewUser() ? 'registerUrl' : 'loginUrl');
         $plainText = str_replace(
             '%URL%',
@@ -204,7 +207,7 @@ class UserModel implements SeablastModelInterface
         $subject = $this->configuration->getString(
             $this->user->isNewUser() ? AuthConstant::SUBJECT_EMAIL_REGISTRATION : AuthConstant::SUBJECT_EMAIL_LOGIN
         );
-        // Volitelně připrav HTML variantu (zachováš čisté plaintext i pro klienty bez HTML)
+        // Optionally prepare an HTML variant while keeping clean plaintext for clients without HTML.
         //        $htmlBody = sprintf(
         //            '<p>%s</p>',
         //            htmlspecialchars(str_replace("\n", ' ', $plainText), ENT_QUOTES, 'UTF-8')

--- a/src/UserModel.php
+++ b/src/UserModel.php
@@ -75,7 +75,8 @@ class UserModel implements SeablastModelInterface
             return (object) [
                     'showLogin' => false,
                     'showLogout' => true,
-                    'message' => 'Nyní jste přihlášeni jako ' . $this->user->getEmail() . ', užijte si to.',
+                    'message' => 'Nyní jste přihlášeni jako ' .
+                        $this->user->getEmail() . ', užijte si to.',
             ];
         }
         if ($this->superglobals->server['REQUEST_METHOD'] === 'GET') {
@@ -125,8 +126,8 @@ class UserModel implements SeablastModelInterface
             return (object) [
                     'showLogin' => true,
                     'showLogout' => false,
-                    'message' => 'Zalogujte se. Na zadaný email vám přijde webová adresa, přes kterou se přihlásíte.'
-                    . ' Žádná hesla nejsou třeba.',
+                    'message' => 'Zalogujte se. Na zadaný email vám přijde webová adresa, '
+                        . 'přes kterou se přihlásíte. Žádná hesla nejsou třeba.',
             ];
         } elseif ($this->superglobals->server['REQUEST_METHOD'] === 'POST') {
             if ((isset($this->superglobals->post['csrfToken'])) && (isset($this->superglobals->post['email']))) {

--- a/tests/SocialLoginGoogleTest.php
+++ b/tests/SocialLoginGoogleTest.php
@@ -1,0 +1,96 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Seablast\Auth\Tests;
+
+use GuzzleHttp\Client;
+use GuzzleHttp\Handler\MockHandler;
+use GuzzleHttp\HandlerStack;
+use GuzzleHttp\Psr7\Response;
+use PHPUnit\Framework\TestCase;
+use Seablast\Auth\AuthConstant;
+use Seablast\Auth\Models\SocialLoginGoogle;
+use Seablast\Seablast\SeablastConfiguration;
+
+class SocialLoginGoogleTest extends TestCase
+{
+    private const GOOGLE_CLIENT_ID = 'test-client.apps.googleusercontent.com';
+
+    public function testReturnsPayloadForValidTokeninfoResponse(): void
+    {
+        $payload = [
+            'aud' => self::GOOGLE_CLIENT_ID,
+            'iss' => 'https://accounts.google.com',
+            'email' => 'user@example.com',
+            'exp' => (string) (time() + 3600),
+        ];
+
+        $model = $this->createModel([
+            new Response(200, [], (string) json_encode($payload)),
+        ]);
+
+        $this->assertSame($payload, $model->authTokenToPayload('valid-id-token'));
+    }
+
+    public function testRejectsExpiredTokeninfoResponse(): void
+    {
+        $model = $this->createModel([
+            new Response(200, [], (string) json_encode([
+                'aud' => self::GOOGLE_CLIENT_ID,
+                'iss' => 'accounts.google.com',
+                'email' => 'user@example.com',
+                'exp' => (string) (time() - 1),
+            ])),
+        ]);
+
+        $this->assertFalse($model->authTokenToPayload('expired-id-token'));
+    }
+
+    public function testRejectsAudienceMismatch(): void
+    {
+        $model = $this->createModel([
+            new Response(200, [], (string) json_encode([
+                'aud' => 'other-client.apps.googleusercontent.com',
+                'iss' => 'https://accounts.google.com',
+                'email' => 'user@example.com',
+                'exp' => (string) (time() + 3600),
+            ])),
+        ]);
+
+        $this->assertFalse($model->authTokenToPayload('wrong-audience-id-token'));
+    }
+
+    public function testRejectsMalformedTokeninfoResponse(): void
+    {
+        $model = $this->createModel([
+            new Response(200, [], '{'),
+        ]);
+
+        $this->assertFalse($model->authTokenToPayload('malformed-response-id-token'));
+    }
+
+    public function testRejectsFailedTokeninfoResponse(): void
+    {
+        $model = $this->createModel([
+            new Response(400, [], (string) json_encode(['error' => 'invalid_token'])),
+        ]);
+
+        $this->assertFalse($model->authTokenToPayload('failed-response-id-token'));
+    }
+
+    /**
+     * @param array<int,Response> $responses
+     * @return SocialLoginGoogle
+     */
+    private function createModel(array $responses): SocialLoginGoogle
+    {
+        $configuration = new SeablastConfiguration();
+        $configuration->setString(AuthConstant::GOOGLE_CLIENT_ID, self::GOOGLE_CLIENT_ID);
+
+        $mock = new MockHandler(array_values($responses));
+        $client = new Client(['handler' => HandlerStack::create($mock)]);
+
+        return new SocialLoginGoogle($configuration, $client);
+    }
+}


### PR DESCRIPTION
### Added

- `AGENTS.md` with project, command, testing, and security guidance for coding agents.
- `IdentityManager::setRememberMeCookieEnabled()` to let bundled models and direct users disable Remember Me cookie creation and reads.
- PHPUnit coverage for Google social-login tokeninfo validation without network or database access.

### Changed

- Updated readme and Composer description wording for current APIs and PHP support.
- Updated `blast.sh` from Seablast v0.2.11 to v0.2.17.3 helper wording and conditional PHPStan PHPUnit plugin installation.
- Adjusted GitHub workflow permissions comments for pull-request comments.
- Replaced session `uniqid()` values with random tokens from the existing token generator.
- `SocialLoginGoogle` accepts an optional Guzzle client for isolated testing.
- Update session access timestamp writes to run only after five minutes of inactivity.

### Fixed

- Escape email and token values in IdentityManager login, token validation, session deletion, and user lookup paths.
- Write queries in IdentityManager now throw `DbmsException` on database errors.
- `AuthConstant::FLAG_REMEMBER_ME_COOKIE` now controls Remember Me cookie creation as well as reading in bundled models.
- Google tokeninfo validation now handles missing or malformed `aud`, `iss`, `email`, and `exp` fields safely.
- Group activation token lookup is explicitly case-insensitive and limited to one matching token.
- Readme `MailOut` usage now matches the `MailOut(SeablastConfiguration $configuration)` constructor.
- Remove never-logged-in users older than 15 minutes before creating or reusing login users.
- Set the query-log user immediately after resolving `user_id`, before refreshing `session_user.updated`

### Security

- Make logout to use deleteSessionToken method
- Social-login failure logging no longer records raw OAuth or ID tokens.
- Session tokens now use cryptographically secure random bytes instead of `uniqid()`.
- Google social-login validation checks audience, issuer, email format, and expiration when present.